### PR TITLE
Fix: Check score is full mark or exit code should be non-zero

### DIFF
--- a/hw1/validate.sh
+++ b/hw1/validate.sh
@@ -7,6 +7,8 @@ tmp_dir=$(mktemp -d -t hw1-XXXXXXXXXX)
 echo "working directory: $tmp_dir"
 cd $tmp_dir
 
+score=0
+
 # question 1
 rm -rf *
 cp $solution_path/countline.sh .
@@ -19,6 +21,7 @@ else
     echo "wrong number ; NO POINT"
   else
     echo "GET POINT 1"
+    score=$(($score + 1))
   fi
 fi
 
@@ -33,6 +36,7 @@ else
     echo "wrong number ; NO POINT"
   else
     echo "GET POINT 1"
+    score=$(($score + 1))
   fi
 fi
 
@@ -48,6 +52,7 @@ else
     echo "expected message not found ; NO POINT"
   else
     echo "GET POINT 1"
+    score=$(($score + 1))
   fi
 fi
 
@@ -62,6 +67,7 @@ else
     echo "wrong number ; NO POINT"
   else
     echo "GET POINT 1"
+    score=$(($score + 1))
   fi
 fi
 
@@ -76,12 +82,20 @@ else
     echo "wrong number ; NO POINT"
   else
     echo "GET POINT 1"
+    score=$(($score + 1))
   fi
 fi
 
 echo "deleting working directory $tmp_dir"
 rm -rf $tmp_dir
 
-exit 0
+# Check score is 5 or exit code should be non-zero
+echo "Score: " $score/5
+
+if [ $score = 5 ]; then
+  exit 0
+else
+  exit 1
+fi
 
 # vim: set fenc=utf8 ff=unix et sw=2 ts=2 sts=2:


### PR DESCRIPTION
## What's new?

Hi. In this PR, I fix the homework 1 CI issue that if score is not full mark the CI should return non-zero exitcode.

![](https://media.discordapp.net/attachments/1112528278004187136/1283360885250854912/image.png?ex=66e7fc76&is=66e6aaf6&hm=7e33992a3cca1cff618a102ea7bcd77287a1514f48cb0c3fafa9e125b6d38139&=&format=webp&quality=lossless&width=1100&height=262)

In this image above, the score is not full mark but the exit code is zero. It will show passed in GitHub Action and  caused misunderstand the homework is passed.

## Implement

 - [x] Fix the issue. Calculate the score, check the score is full mark or return non-zero exitcode.

## How to review it

  - [x] Check when `countline.sh` is not full mark, the `validate.sh` should return exitcode 1.
  - [x] Check when `countline.sh` is full mark, the `validate.sh` should return exitcode 0.
